### PR TITLE
feat: Add tolerations to get_service_config

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -18,6 +18,7 @@ require (
 	go.etcd.io/bbolt v1.3.7
 	go.starlark.net v0.0.0-20230224151120-c52844e64a10
 	gopkg.in/godo.v2 v2.0.9
+	k8s.io/api v0.27.2
 )
 
 require (
@@ -95,7 +96,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.27.2 // indirect
 	k8s.io/apimachinery v0.27.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/utils v0.0.0-20230711102312-30195339c3c7 // indirect


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

- Adds the `tolerations` list to the return value of `kurtosistest.get_service_config`