### PR TITLE
chore: Ignore .kurtosis-test directory when matching files

### DIFF
--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"kurtosis-test/cli/core"
@@ -102,7 +103,9 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Let's now get the list of matching test files
-	testFiles, testFilesErr := core.ListMatchingTestFiles(project, testFilePatternStr)
+	// 
+	// We need to make sure to ignore the test files in the temporary directory
+	testFiles, testFilesErr := core.ListMatchingTestFiles(project, testFilePatternStr, filepath.Join(tempDirRootStr, "**"))
 	if testFilesErr != nil {
 		logrus.Errorf("Error matching test files in project: %v", testFilesErr)
 

--- a/cli/core/matching_test.go
+++ b/cli/core/matching_test.go
@@ -1,0 +1,59 @@
+package core_test
+
+import (
+	"kurtosis-test/cli/commands"
+	"kurtosis-test/cli/core"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListMatchingTestFilesIgnorePattern(t *testing.T) {
+	t.Run("should not ignore any files if called with empty ignored pattern", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+
+		testProjectPath := filepath.Join(cwd, "testdata", "test_project")
+		testProject := &core.KurtosisTestProject{
+			Path: testProjectPath,
+		}
+
+		testFiles, err := core.ListMatchingTestFiles(testProject, commands.KurtosisTestDefaultTestFilePattern, "")
+		require.NoError(t, err)
+		require.Equal(t, []*core.TestFile{{Project: testProject, Path: "test/nonignored_test.star"}, {Project: testProject, Path: "ignored/ignored_test.star"}}, testFiles)
+	})
+
+	t.Run("should ignore matching files if called with relative ignored pattern", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+
+		testProjectPath := filepath.Join(cwd, "testdata", "test_project")
+		testProject := &core.KurtosisTestProject{
+			Path: testProjectPath,
+		}
+
+		ignoredTestFilePattern := filepath.Join("ignored", "**")
+
+		testFiles, err := core.ListMatchingTestFiles(testProject, commands.KurtosisTestDefaultTestFilePattern, ignoredTestFilePattern)
+		require.NoError(t, err)
+		require.Equal(t, []*core.TestFile{{Project: testProject, Path: "test/nonignored_test.star"}}, testFiles)
+	})
+
+	t.Run("should ignore matching files if called with absolute ignored pattern", func(t *testing.T) {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+
+		testProjectPath := filepath.Join(cwd, "testdata", "test_project")
+		testProject := &core.KurtosisTestProject{
+			Path: testProjectPath,
+		}
+
+		ignoredTestFilePattern := filepath.Join(testProjectPath, "ignored", "**")
+
+		testFiles, err := core.ListMatchingTestFiles(testProject, commands.KurtosisTestDefaultTestFilePattern, ignoredTestFilePattern)
+		require.NoError(t, err)
+		require.Equal(t, []*core.TestFile{{Project: testProject, Path: "test/nonignored_test.star"}}, testFiles)
+	})
+}

--- a/cli/core/testdata/test_project/ignored/ignored_test.star
+++ b/cli/core/testdata/test_project/ignored/ignored_test.star
@@ -1,0 +1,2 @@
+def test_if_not_ignored(plan):
+    return True

--- a/cli/core/testdata/test_project/test/nonignored_test.star
+++ b/cli/core/testdata/test_project/test/nonignored_test.star
@@ -1,0 +1,2 @@
+def test_if_matches(plan):
+    return True


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

`.kurtosis-test` can potentially contain unit tests that need to be ignored since we only want to run tests from the current project